### PR TITLE
Set nav button background-color to transparent

### DIFF
--- a/hook/extension/js/modifiers/MenuModifier.js
+++ b/hook/extension/js/modifiers/MenuModifier.js
@@ -25,7 +25,7 @@ MenuModifier.prototype = {
             menuStyle = "style='font-size:20px; background-color: #fc4c02; color: white;'"; //TODO Globalize colors
             menuIcon = this.appResources_.menuIconBlack;
         } else {
-            menuStyle = "style='font-size:20px; background-color: white; color: #fc4c02;'"; //TODO Globalize colors
+            menuStyle = "style='font-size:20px; background-color: transparent; color: #fc4c02;'"; //TODO Globalize colors
             menuIcon = this.appResources_.menuIconOrange;
         }
 


### PR DESCRIPTION
Setting the default navigation background-color to transparent improves the integration into the nav bar on Strava and changes this:

![screen shot 2015-05-12 at 14 39 04](https://cloud.githubusercontent.com/assets/627280/7588623/1e2b6f48-f8b6-11e4-9f87-080ea3aa51c8.png)

... to this ...

![screen shot 2015-05-12 at 14 39 16](https://cloud.githubusercontent.com/assets/627280/7588630/248d8d26-f8b6-11e4-9335-e653571b7f58.png)

Note the nice grey underline under the button.