### PR TITLE
Avg climbing pace fix

### DIFF
--- a/hook/extension/js/modifiers/extendedActivityData/RunningExtendedActivityDataModifier.js
+++ b/hook/extension/js/modifiers/extendedActivityData/RunningExtendedActivityDataModifier.js
@@ -37,12 +37,12 @@ var RunningExtendedActivityDataModifier = AbstractExtendedActivityDataModifier.e
                 this.insertContentAtGridPosition(1, 0, q3Move, '75% Quartile Pace', '/' + distanceUnits, 'displayAdvancedSpeedData');
             }
 
-            // ... 
+            // Avg climb pace
             var climbSpeed = '-';
             if (this.analysisData_.gradeData && this.userSettings_.displayAdvancedGradeData) {
                 climbSpeed = Helper.secondsToHHMMSS((this.analysisData_.gradeData.upFlatDownMoveData.up / speedUnitFactor).toFixed(0)).replace('00:', '');
+                this.insertContentAtGridPosition(1, 2, climbSpeed, 'Avg climbing pace', speedUnitPerhour, 'displayAdvancedGradeData');
             }
-            this.insertContentAtGridPosition(1, 2, climbSpeed, 'Avg climbing pace', speedUnitPerhour, 'displayAdvancedGradeData');
         },
 
         setDataViewsNeeded: function() {

--- a/hook/extension/js/modifiers/extendedActivityData/RunningExtendedActivityDataModifier.js
+++ b/hook/extension/js/modifiers/extendedActivityData/RunningExtendedActivityDataModifier.js
@@ -41,7 +41,7 @@ var RunningExtendedActivityDataModifier = AbstractExtendedActivityDataModifier.e
             var climbSpeed = '-';
             if (this.analysisData_.gradeData && this.userSettings_.displayAdvancedGradeData) {
                 climbSpeed = Helper.secondsToHHMMSS((this.analysisData_.gradeData.upFlatDownMoveData.up / speedUnitFactor).toFixed(0)).replace('00:', '');
-                this.insertContentAtGridPosition(1, 2, climbSpeed, 'Avg climbing pace', speedUnitPerhour, 'displayAdvancedGradeData');
+                this.insertContentAtGridPosition(1, 2, climbSpeed, 'Avg climbing pace', '/' + distanceUnits, 'displayAdvancedGradeData');
             }
         },
 


### PR DESCRIPTION
This PR is aiming to fix:
- The logic of when it should be displayed. From what I understood, it should be inside the `if (this.analysisData_.gradeData && this.userSettings_.displayAdvancedGradeData)`, just like the others. When it's turned on, we show it.
- The unit of 'Avg climbing pace', as shown in the screenshots below.

Before fixing:
![avg-climbing-pace-current](https://cloud.githubusercontent.com/assets/1937586/8081396/7cd43fa6-0fc8-11e5-815d-7cb899d4b88b.jpg)

After fixing:
![avg-climbing-pace-fixed](https://cloud.githubusercontent.com/assets/1937586/8081398/83643e84-0fc8-11e5-87fd-75127f7c9a09.jpg)
