### PR TITLE
Update help message for 'Move Ratio'

### DIFF
--- a/hook/extension/options/app/modules/SettingsSectionsModule.js
+++ b/hook/extension/options/app/modules/SettingsSectionsModule.js
@@ -7,7 +7,7 @@ settingsSectionsModule.data = [{
         optionType: 'checkbox',
         optionTitle: 'Move Ratio',
         optionLabels: ['Cycling', 'Running'],
-        optionHtml: 'Add your activity ratio in activity page. Try to always reach the value of <strong>1</strong>. The value <strong>1</strong> means that you got no rest during your cycling activity. <br /><br /><strong>MOVE YOURSELF !!</strong>',
+        optionHtml: 'Add your activity ratio in activity page. Try to always reach the value of <strong>1</strong>. The value <strong>1</strong> means that you got no rest during your activity. <br /><br /><strong>MOVE YOURSELF !!</strong>',
     }, {
         optionKey: 'displayMotivationScore',
         optionType: 'checkbox',


### PR DESCRIPTION
Update help message for 'Move Ratio', as this option is available for  both cycling and running.

Therefore, it is better to say "during your activity" in general, instead of 'during your cycling activity'.

![help-for-move-ratio](https://cloud.githubusercontent.com/assets/1937586/8081598/28622e9a-0fca-11e5-985c-a8c3ef97d883.jpg)
