### PR TITLE
Median cadence and cadence std dev added

### DIFF
--- a/hook/extension/js/modifiers/extendedActivityData/CyclingExtendedActivityDataModifier.js
+++ b/hook/extension/js/modifiers/extendedActivityData/CyclingExtendedActivityDataModifier.js
@@ -40,6 +40,13 @@ var CyclingExtendedActivityDataModifier = AbstractExtendedActivityDataModifier.e
                 climbSpeed = (this.analysisData_.gradeData.upFlatDownMoveData.up * speedUnitFactor).toFixed(1);
             }
             this.insertContentAtGridPosition(1, 2, climbSpeed, 'Avg climbing speed', speedUnitPerhour, 'displayAdvancedGradeData');
+			
+			 // Cadence
+            var medianCadence = '-';
+            if (this.analysisData_.cadenceData && this.userSettings_.displayCadenceData) {
+                medianCadence = this.analysisData_.cadenceData.medianCadence;
+                this.insertContentAtGridPosition(0, 3, medianCadence, 'Median Cadence', ' rpm <span class="summarySubGridTitle">(&sigma; :' + this.analysisData_.cadenceData.standardDeviationCadence + ' )</span>', 'displayAdvancedCadenceData');
+            }
         },
 
         setDataViewsNeeded: function() {

--- a/hook/extension/js/processors/ActivityProcessor.js
+++ b/hook/extension/js/processors/ActivityProcessor.js
@@ -529,6 +529,10 @@ ActivityProcessor.prototype = {
 
         var cadenceRatioOnMovingTime = cadenceOnMoveSampleCount / movingSampleCount;
         var averageCadenceOnMovingTime = cadenceSumOnMoving / cadenceOnMovingCount;
+		
+		
+        var varianceCadence = (cadenceSumOnMoving / cadenceOnMoveSampleCount) - Math.pow(averageCadenceOnMovingTime, 2);
+        var standardDeviationCadence = (varianceCadence > 0) ? Math.sqrt(varianceCadence) : 0;
 
         // Update zone distribution percentage
         for (var zone in cadenceZones) {
@@ -543,6 +547,7 @@ ActivityProcessor.prototype = {
             'cadencePercentageMoving': cadenceRatioOnMovingTime * 100,
             'cadenceTimeMoving': (cadenceRatioOnMovingTime * activityStatsMap.movingTime),
             'averageCadenceMoving': averageCadenceOnMovingTime,
+			'standardDeviationCadence' : standardDeviationCadence,
             'crankRevolutions': (averageCadenceOnMovingTime / 60 * activityStatsMap.movingTime),
             'lowerQuartileCadence': Helper.lowerQuartile(cadenceArraySorted),
             'medianCadence': Helper.median(cadenceArraySorted),


### PR DESCRIPTION
I've added median cadence and cadence standard deviation to the content summary grid (if user has opted to include cadence stats in the extended views). I (and a few of my friends) found this information useful during focused cadence training.