### PR TITLE
#10 - Translation enabled for Health settings and Zone Settings pages.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,6 +65,7 @@ var OPT_FILES = [
     'hook/extension/node_modules/bootstrap/dist/**/*.*',
     'hook/extension/node_modules/angular/angular.min.js',
     'hook/extension/node_modules/angular-route/angular-route.min.js',
+    'hook/extension/node_modules/angular-sanitize/angular-sanitize.min.js',
     'hook/extension/node_modules/angular-bootstrap/ui-bootstrap.min.js',
     'hook/extension/node_modules/angular-bootstrap/ui-bootstrap-tpls.min.js',
     'hook/extension/node_modules/underscore/underscore-min.js',

--- a/hook/extension/locales/en-GB.json
+++ b/hook/extension/locales/en-GB.json
@@ -141,6 +141,7 @@
             "dist_last_30d": "#########"
         },
         "settings": {
+            "zone": "########",
             "common": {
                 "extendedStas_section": "########",
                 "disp_active_ratio": "########",
@@ -183,6 +184,47 @@
                 "wind_speed": "########",
                 "misc": "########",
                 "hide_premium": "########"
+            },
+            "healthSettings": {
+                "max_hrr": "########",
+                "rest_hrr": "########",
+                "cyc_func_threshold_pow": "########",
+                "your_hrr_zones": "########",
+                "save_zone": "########",
+                "add_last_zone": "########",
+                "del_last_zone": "########",
+                "reset_zone": "########",
+                "health_zone_explain": [
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########",
+                    "########"
+                ]
+            },
+            "zoneSettings": {
+                "cyc_speed": "########",
+                "run_pace": "########",
+                "cyc_power": "########",
+                "cyc_cadence": "########",
+                "run_cadence": "########",
+                "grade": "########",
+                "elevation": "########",
+                "asc_speed": "########",
+                "export_zone": "########",
+                "import_zone": "########"
             }
         }
     }

--- a/hook/extension/locales/en-GB.json
+++ b/hook/extension/locales/en-GB.json
@@ -141,6 +141,15 @@
             "dist_last_30d": "#########"
         },
         "settings": {
+            "common_sec": "########",
+            "health_sec": "########",
+            "zone_sec": "########",
+            "rel_notes_sec": "########",
+            "about_sec": "########",
+            "donate_sec": "########",
+            "share_sec": "########",
+            "what_next": "########",
+            "report_bug": "########",
             "zone": "########",
             "common": {
                 "extendedStas_section": "########",

--- a/hook/extension/locales/root.json
+++ b/hook/extension/locales/root.json
@@ -141,6 +141,7 @@
             "dist_last_30d": "Distance last 30d"
         },
         "settings": {
+            "zone": "Zone",
             "common": {
                 "extendedStas_section": "Activities Extended Data",
                 "disp_active_ratio": "Move Ratio",
@@ -183,6 +184,47 @@
                 "wind_speed": "Wind Speed",
                 "misc": "Miscellaneous",
                 "hide_premium": "Hide Premium visuals"
+            },
+            "healthSettings": {
+                "max_hrr": "Max heartrate",
+                "rest_hrr": "Resting heartrate",
+                "cyc_func_threshold_pow": "Cycling Functional Threshold Power",
+                "your_hrr_zones": "Your Heart Rate Reserve (HRR) zones",
+                "save_zone": "Save Zones",
+                "add_last_zone": "Add a Last Zone",
+                "del_last_zone": "Del Last Zone",
+                "reset_zone": "Reset Zones",
+                "health_zone_explain": [
+                    "<h3>How to use custom Heart Rate Reserve zones?</h3><blockquote>",
+                    "<h4>Edit existing zone</h4><blockquote>",
+                    "Click into HRR fields of the zone you want to edit. A zone is always defined between 2 HRR fields.<br/>",
+                    "<br/>Hint: You can use input arrows or keyboard arrows to set the value.</blockquote>",
+                    "<h4>Add a Last HRR zone</h4><blockquote>",
+                    "Click “Add a Last Zone” button to add a new zone at the end of current zones. The previous last zone will be split twice to add the new zone.</blockquote>",
+                    "<h4>Remove HRR zone</h4><blockquote>",
+                    "Click “Del Last Zone” button to remove the zone at the end of current zones. The 2 latest zones will be merged to perform this operation.</blockquote>",
+                    "<h4>Reset HRR zones</h4><blockquote>",
+                    "Click “Reset Zones” to apply default factory zones.</blockquote></blockquote>",
+                    "<h3>What is Heart Rate Reserve?</h3><blockquote>",
+                    "Heart Rate Reserve (HRR) is the difference between your Maximum Heart Rate (Max HR) and Resting Heart Rate (Rest HR). This is basically your global heart capacity :)<br/>",
+                    "<br/>%HRR = 0% is your Rest HR<br/>%HRR = 100% is your Max HR</blockquote>",
+                    "<h3>What are Heart Rate Reserve Zones?</h3><blockquote>",
+                    "Heart Rate Reserve Zones represent a distribution of your heart efforts during an activity into zones. Each zone has a beginning and ending HRR value.</blockquote>",
+                    "<h3>Where to see HRR Zone distribution?</h3><blockquote>",
+                    "Inside a Strava activity. Of course you must have heart rate data associated to your activity.</blockquote>"
+                ]
+            },
+            "zoneSettings": {
+                "cyc_speed": "Cycling Speed",
+                "run_pace": "Running Pace",
+                "cyc_power": "Cycling Power",
+                "cyc_cadence": "Cycling Cadence",
+                "run_cadence": "Running Cadence",
+                "grade": "Grade",
+                "elevation": "Elevation",
+                "asc_speed": "Ascent speed",
+                "export_zone": "Export...",
+                "import_zone": "Import..."
             }
         }
     }

--- a/hook/extension/locales/root.json
+++ b/hook/extension/locales/root.json
@@ -141,6 +141,15 @@
             "dist_last_30d": "Distance last 30d"
         },
         "settings": {
+            "common_sec": "Common",
+            "health_sec": "Health",
+            "zone_sec": "Zones",
+            "rel_notes_sec": "Release Notes",
+            "about_sec": "About",
+            "donate_sec": "Donate",
+            "share_sec": "Share",
+            "what_next": "What's next?",
+            "report_bug": "Report",
             "zone": "Zone",
             "common": {
                 "extendedStas_section": "Activities Extended Data",

--- a/hook/extension/options/app/App.js
+++ b/hook/extension/options/app/App.js
@@ -1,7 +1,7 @@
 /**
  * Declaring Angular App
  */
-var app = angular.module("App", ['ngRoute', 'ui.bootstrap', 'ui.checkbox']);
+var app = angular.module("App", ['ngRoute', 'ui.bootstrap', 'ui.checkbox', 'ngSanitize']);
 
 app.config(['$routeProvider', function($routeProvider) {
 

--- a/hook/extension/options/app/controllers/MainController.js
+++ b/hook/extension/options/app/controllers/MainController.js
@@ -1,12 +1,25 @@
 /**
  * Declaring MainController
  */
-app.controller('MainController', function($scope, $location) {
+app.controller('MainController', ['$scope', '$location', 'TranslationService', function($scope, $location, TranslationService) {
+
+    // Start application activities only after translation initialization
+    TranslationService.init(function () {
+        $scope.common_title = TranslationService.formatMessage('settings/common_sec');
+        $scope.health_title = TranslationService.formatMessage('settings/health_sec');
+        $scope.zone_title = TranslationService.formatMessage('settings/zone_sec');
+        $scope.rel_notes_title = TranslationService.formatMessage('settings/rel_notes_sec');
+        $scope.about_title = TranslationService.formatMessage('settings/about_sec');
+        $scope.donate_title = TranslationService.formatMessage('settings/donate_sec');
+        $scope.share_title = TranslationService.formatMessage('settings/share_sec');
+        $scope.what_next = TranslationService.formatMessage('settings/what_next');
+        $scope.report_bug = TranslationService.formatMessage('settings/report_bug');
+    });
 
     // Bootstrap active class name for active menu
     $scope.headerActiveClassName = 'active';
 
-    // Clear healthSettings fields on call 
+    // Clear healthSettings fields on call
     $scope.resetFields = function() {
         $scope.CommonSettingsActive = null;
         $scope.healthSettingsActive = null;
@@ -54,4 +67,4 @@ app.controller('MainController', function($scope, $location) {
             $scope.shareActive = $scope.headerActiveClassName;
         }
     });
-});
+}]);

--- a/hook/extension/options/app/controllers/XtdZonesSettingsController.js
+++ b/hook/extension/options/app/controllers/XtdZonesSettingsController.js
@@ -1,93 +1,111 @@
-app.controller("XtdZonesSettingsController", ['$scope', '$location', 'ChromeStorageService', function($scope, $location, ChromeStorageService) {
+app.controller("XtdZonesSettingsController", ['$scope', '$location', 'ChromeStorageService', 'TranslationService', function($scope, $location, ChromeStorageService, TranslationService) {
 
-    // List of Xtended data to be customize
-    $scope.xtdListOptions = [{
-        name: 'Cycling Speed',
-        value: 'speed',
-        units: 'KPH',
-        step: 0.1,
-        min: 0,
-        max: 9999
-    }, {
-        name: 'Running Pace',
-        value: 'pace',
-        units: 'Seconds', // s/mi?!
-        step: 1,
-        min: 0,
-        max: 9999
-    }, {
-        name: 'Cycling Power',
-        value: 'power',
-        units: 'Watts',
-        step: 1,
-        min: 0,
-        max: 9999
-    }, {
-        name: 'Cycling Cadence',
-        value: 'cyclingCadence',
-        units: 'RPM',
-        step: 1,
-        min: 0,
-        max: 9999
-    }, {
-        name: 'Running Cadence',
-        value: 'runningCadence',
-        units: 'SPM',
-        step: 0.1,
-        min: 0,
-        max: 9999
-    }, {
-        name: 'Grade',
-        value: 'grade',
-        units: '%',
-        step: 0.1,
-        min: -9999,
-        max: 9999
-    }, {
-        name: 'Elevation',
-        value: 'elevation',
-        units: 'm',
-        step: 5,
-        min: 0,
-        max: 9999
-    }, {
-        name: 'Ascent speed',
-        value: 'ascent',
-        units: 'Vm/h',
-        step: 5,
-        min: 0,
-        max: 9999
-    }];
+    TranslationService.init(function () {
 
-    ChromeStorageService.fetchUserSettings(function(userSettingsSynced) {
+        $scope.xtdListOptions = [{
+            name: 'Cycling Speed',
+            transKey: 'cyc_speed',
+            value: 'speed',
+            units: 'KPH',
+            step: 0.1,
+            min: 0,
+            max: 9999
+        }, {
+            name: 'Running Pace',
+            transKey: 'run_pace',
+            value: 'pace',
+            units: 'Seconds', // s/mi?!
+            step: 1,
+            min: 0,
+            max: 9999
+        }, {
+            name: 'Cycling Power',
+            transKey: 'cyc_power',
+            value: 'power',
+            units: 'Watts',
+            step: 1,
+            min: 0,
+            max: 9999
+        }, {
+            name: 'Cycling Cadence',
+            transKey: 'cyc_cadence',
+            value: 'cyclingCadence',
+            units: 'RPM',
+            step: 1,
+            min: 0,
+            max: 9999
+        }, {
+            name: 'Running Cadence',
+            transKey: 'run_cadence',
+            value: 'runningCadence',
+            units: 'SPM',
+            step: 0.1,
+            min: 0,
+            max: 9999
+        }, {
+            name: 'Grade',
+            transKey: 'grade',
+            value: 'grade',
+            units: '%',
+            step: 0.1,
+            min: -9999,
+            max: 9999
+        }, {
+            name: 'Elevation',
+            transKey: 'elevation',
+            value: 'elevation',
+            units: 'm',
+            step: 5,
+            min: 0,
+            max: 9999
+        }, {
+            name: 'Ascent speed',
+            transKey: 'asc_speed',
+            value: 'ascent',
+            units: 'Vm/h',
+            step: 5,
+            min: 0,
+            max: 9999
+        }];
 
-        $scope.zones = userSettingsSynced.zones;
-
-        $scope.switchZonesFromXtdItem = function(xtdData) {
-
-            // Select cycling speed by default
-            $scope.xtdData = xtdData;
-            $scope.xtdZones = $scope.zones[$scope.xtdData.value];
-        };
-
-        $scope.toggleSelectOption = function(listItem) {
-            // Load source on toggle option
-            // And inject
-            // Mocking xtd source
-            $scope.switchZonesFromXtdItem(listItem);
-        };
-
-        // // Apply search text if searchText GET param exist
-        if ($location.search().selectZoneValue) {
-
-            var selectZoneValue = $location.search().selectZoneValue;
-
-            var item = _.findWhere($scope.xtdListOptions, {
-                value: selectZoneValue
-            });
-
-            $scope.switchZonesFromXtdItem(item);
+        for (var i = 0; i < $scope.xtdListOptions.length; i++) {
+            var transPath = 'settings/zoneSettings/' + $scope.xtdListOptions[i].transKey;
+            var transText = TranslationService.formatMessage(transPath);
+            $scope.xtdListOptions[i].name = transText;
         }
 
-    }.bind(this));
+        ChromeStorageService.fetchUserSettings(function(userSettingsSynced) {
+
+            $scope.zones = userSettingsSynced.zones;
+
+            $scope.switchZonesFromXtdItem = function(xtdData) {
+
+                // Select cycling speed by default
+                $scope.xtdData = xtdData;
+                $scope.xtdZones = $scope.zones[$scope.xtdData.value];
+            };
+
+            $scope.toggleSelectOption = function(listItem) {
+                // Load source on toggle option
+                // And inject
+                // Mocking xtd source
+                $scope.switchZonesFromXtdItem(listItem);
+            };
+
+            // // Apply search text if searchText GET param exist
+            if ($location.search().selectZoneValue) {
+
+                var selectZoneValue = $location.search().selectZoneValue;
+
+                var item = _.findWhere($scope.xtdListOptions, {
+                    value: selectZoneValue
+                });
+
+                $scope.switchZonesFromXtdItem(item);
+            }
+
+        }.bind(this));
+
+    });
+    // List of Xtended data to be customize
 }]);

--- a/hook/extension/options/app/directives/hrZones/templates/healthCustomZones.html
+++ b/hook/extension/options/app/directives/hrZones/templates/healthCustomZones.html
@@ -4,18 +4,18 @@
         <div>{{hrZones | json}}</div>
     </div>
     <div class="hrZoneAddRemoveTop">
-        <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveHrZones()">Save Zones</button>
-        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addHrZone()">Add a Last Zone</button>
-        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeHrZone()">Del Last Zone</button>
-        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetHrZone()">Reset Zones</button>
+        <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveHrZones()">{{'settings/healthSettings/save_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addHrZone()">{{'settings/healthSettings/add_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeHrZone()">{{'settings/healthSettings/del_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetHrZone()">{{'settings/healthSettings/reset_zone'| translationFilter}}</button>
     </div>
     <div data-ng-repeat="zone in hrZones">
         <div data-hr-zone="zone" data-hr-zone-id="{{$index}}" data-previous-from-hrr="{{hrZones[$index - 1].fromHrr}}" data-next-to-hrr="{{hrZones[$index + 1].toHrr}}" data-hr-zone-first="{{$index == 0}}" data-hr-zone-last="{{$index == (hrZones.length - 1)}}" data-user-max-hr="{{userMaxHr}}" data-user-rest-hr="{{userRestHr}}"></div>
     </div>
     <div class="hrZoneAddRemoveBottom">
-    <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveHrZones()">Save Zones</button>
-        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addHrZone()">Add a Last Zone</button>
-        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeHrZone()">Del Last Zone</button>
-        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetHrZone()">Reset Zones</button>
+    <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveHrZones()">{{'settings/healthSettings/save_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addHrZone()">{{'settings/healthSettings/add_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeHrZone()">{{'settings/healthSettings/del_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetHrZone()">{{'settings/healthSettings/reset_zone'| translationFilter}}</button>
     </div>
 </div>

--- a/hook/extension/options/app/directives/hrZones/templates/hrZone.html
+++ b/hook/extension/options/app/directives/hrZones/templates/hrZone.html
@@ -29,7 +29,7 @@
         <tr>
             <td align="center"></td>
             <td>
-                <span class="printableZoneId">Zone {{printableZoneId}}</span>
+                <span class="printableZoneId">{{'settings/zone'| translationFilter}} {{printableZoneId}}</span>
             </td>
             <td></td>
         </tr>

--- a/hook/extension/options/app/directives/xtdZones/templates/xtdZone.html
+++ b/hook/extension/options/app/directives/xtdZones/templates/xtdZone.html
@@ -29,7 +29,7 @@
         <tr>
             <td align="center"></td>
             <td>
-                <span class="printableZoneId">Zone {{printableZoneId}}</span>
+                <span class="printableZoneId">{{'settings/zone'| translationFilter}} {{printableZoneId}}</span>
             </td>
             <td></td>
         </tr>

--- a/hook/extension/options/app/directives/xtdZones/templates/xtdZones.html
+++ b/hook/extension/options/app/directives/xtdZones/templates/xtdZones.html
@@ -6,12 +6,12 @@
     <div class="hrZoneAddRemoveTop">
         Step
         <input class="form-control input-md" type="number" data-ng-model="xtdDataSelected.step" min="0" data-popover="Enter step for zone precision eg 0.1, 0.01, 0.001, 0.25, ..." style="width: 120px; display: inline;" />
-        <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveZones()">Save Zones</button>
-        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addZone()">Add a Last Zone</button>
-        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeZone()">Del Last Zone</button>
-        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetZone()">Reset Zones</button>
-        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="export()">Export...</button>
-        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="import()">Import...</button>
+        <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveZones()">{{'settings/healthSettings/save_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addZone()">{{'settings/healthSettings/add_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeZone()">{{'settings/healthSettings/del_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetZone()">{{'settings/healthSettings/reset_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="export()">{{'settings/zoneSettings/export_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="import()">{{'settings/zoneSettings/import_zone'| translationFilter}}</button>
     </div>
     <div data-ng-repeat="xtdZone in xtdZones">
         <div data-xtd-zone="xtdZone" data-zone-id="{{$index}}" data-previous-from="{{xtdZones[$index - 1].from}}" data-next-to="{{xtdZones[$index + 1].to}}" data-xtd-zone-first="{{$index == 0}}" data-xtd-zone-last="{{$index == (xtdZones.length - 1)}}" data-xtd-data-selected="xtdDataSelected"></div>
@@ -19,11 +19,11 @@
     <div class="hrZoneAddRemoveBottom">
         Step
         <input class="form-control input-md" type="number" data-ng-model="xtdDataSelected.step" min="0" data-popover="Enter step for zone precision eg 0.1, 0.01, 0.001, 0.25, ..." style="width: 120px; display: inline;" />
-        <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveZones()">Save Zones</button>
-        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addZone()">Add a Last Zone</button>
-        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeZone()">Del Last Zone</button>
-        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetZone()">Reset Zones</button>
-        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="export()">Export...</button>
-        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="import()">Import...</button>
+        <button type="button" class="btn btn-primary zoneActionButton" data-ng-click="saveZones()">{{'settings/healthSettings/save_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-success zoneActionButton" data-ng-click="addZone()">{{'settings/healthSettings/add_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-danger zoneActionButton" data-ng-click="removeZone()">{{'settings/healthSettings/del_last_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-warning zoneActionButton" data-ng-click="resetZone()">{{'settings/healthSettings/reset_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="export()">{{'settings/zoneSettings/export_zone'| translationFilter}}</button>
+        <button type="button" class="btn btn-default zoneActionButton" data-ng-click="import()">{{'settings/zoneSettings/import_zone'| translationFilter}}</button>
     </div>
 </div>

--- a/hook/extension/options/app/filters/TranslationFilter.js
+++ b/hook/extension/options/app/filters/TranslationFilter.js
@@ -1,0 +1,6 @@
+app.filter('translationFilter', ['TranslationService', function(TranslationService) {
+    return function(transKey) {
+            var subsVals = "";
+            return TranslationService.formatMessage(transKey, subsVals);
+    };
+}]);

--- a/hook/extension/options/app/index.html
+++ b/hook/extension/options/app/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="css/app.css">
     <link rel="stylesheet" href="../../node_modules/bootstrap/dist/css/bootstrap.min.css">
     <script src="../../node_modules/angular/angular.min.js"></script>
+    <script src="../../node_modules/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../../node_modules/angular-route/angular-route.min.js"></script>
     <script src="../../node_modules/angular-bootstrap/ui-bootstrap.min.js"></script>
     <script src="../../node_modules/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
@@ -60,6 +61,7 @@
     <!-- Angular filters -->
     <script src="filters/HrrToBpmFilter.js"></script>
     <script src="filters/XtdDataFilter.js"></script>
+    <script src="filters/TranslationFilter.js"></script>
 </body>
 
 </html>

--- a/hook/extension/options/app/views/headerNav.html
+++ b/hook/extension/options/app/views/headerNav.html
@@ -6,31 +6,31 @@
         <div id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
                 <li class="{{CommonSettingsActive}}">
-                    <a href="#/commonSettings"><img src="img/ic_settings_24px.svg" /> Common</a>
+                    <a href="#/commonSettings"><img src="img/ic_settings_24px.svg" /> {{common_title}}</a>
                 </li>
                 <li class="{{healthSettingsActive}}">
-                    <a href="#/healthSettings"><img src="img/ic_favorite_24px.svg" /> Health</a>
+                    <a href="#/healthSettings"><img src="img/ic_favorite_24px.svg" /> {{health_title}}</a>
                 </li>
                 <li class="{{zonesSettingsActive}}">
-                    <a href="#/zonesSettings"><img src="img/ic_format_line_spacing_24px.svg" /> Zones</a>
+                    <a href="#/zonesSettings"><img src="img/ic_format_line_spacing_24px.svg" /> {{zone_title}}</a>
                 </li>
                 <li class="{{releaseNotesActive}}">
-                    <a href="#/releaseNotes"><img src="img/ic_system_update_24px.svg" /> Release Notes</a>
+                    <a href="#/releaseNotes"><img src="img/ic_system_update_24px.svg" /> {{rel_notes_title}}</a>
                 </li>
                 <li class="{{aboutActive}}">
-                    <a href="#/about"><img src="img/ic_info_outline_24px.svg" /> About</a>
+                    <a href="#/about"><img src="img/ic_info_outline_24px.svg" /> {{about_title}}</a>
                 </li>
                 <li class="{{donateActive}}">
-                    <a href="#/donate"><img src="img/ic_attach_money_24px.svg" /> Donate</a>
+                    <a href="#/donate"><img src="img/ic_attach_money_24px.svg" /> {{donate_title}}</a>
                 </li>
                 <li class="{{shareActive}}">
-                    <a href="#/share"><img src="img/ic_share_24px.svg" /> Share</a>
+                    <a href="#/share"><img src="img/ic_share_24px.svg" /> {{share_title}}</a>
                 </li>
                 <li>
-                    <a href="https://twitter.com/champagnethomas" target="_blank"><img src="img/twitter.svg" /> What's next?</a>
+                    <a href="https://twitter.com/champagnethomas" target="_blank"><img src="img/twitter.svg" /> {{what_next}}</a>
                 </li>
                 <li>
-                    <a href="https://chrome.google.com/webstore/detail/stravistix/dhiaggccakkgdfcadnklkbljcgicpckn/support" target="_blank"><img src="img/ic_bug_report_24px.svg" /> Report</a>
+                    <a href="https://chrome.google.com/webstore/detail/stravistix/dhiaggccakkgdfcadnklkbljcgicpckn/support" target="_blank"><img src="img/ic_bug_report_24px.svg" /> {{report_bug}}</a>
                 </li>
             </ul>
         </div>

--- a/hook/extension/options/app/views/healthSettings.html
+++ b/hook/extension/options/app/views/healthSettings.html
@@ -10,7 +10,7 @@
                 </tr>
                 <tr>
                     <td>
-                        Max heartrate
+                        {{'settings/healthSettings/max_hrr' | translationFilter }}
                     </td>
                     <td>
                         <input name="userMaxHr" type="number" min="{{userRestHr + 10}}" max="300" class="form-control input-lg" data-ng-model="userMaxHr" placeholder="Enter max HR" data-ng-change="userMaxHrChanged()" data-ng-keydown="avoidInputKeyEdit($event)" data-popover="Use arrows &#8645; to set your MAX heart rate in beat per minute (bpm)." data-popover-trigger="mouseenter"></input>
@@ -21,7 +21,7 @@
                 </tr>
                 <tr>
                     <td>
-                        Resting heartrate
+                        {{'settings/healthSettings/rest_hrr' | translationFilter }}
                     </td>
                     <td>
                         <input name="userRestHr" type="number" min="10" max="{{userMaxHr - 10}}" class="form-control input-lg" data-ng-model="userRestHr" placeholder="Enter rest HR" data-ng-change="userRestHrChanged()" data-ng-keydown="avoidInputKeyEdit($event)" data-popover="Use arrows &#8645; to set your REST heart rate in beat per minute (bpm)." data-popover-trigger="mouseenter"></input>
@@ -32,7 +32,7 @@
                 </tr>
                 <tr>
                     <td>
-                        Cycling Functional Threshold Power
+                        {{'settings/healthSettings/cyc_func_threshold_pow' | translationFilter }}
                     </td>
                     <td>
                         <input name="userFTP" type="number" min="10" max="2500" class="form-control input-lg" data-ng-model="userFTP" placeholder="Enter your FTP" data-ng-pattern="/^[0-9]+$/" data-ng-change="ftpHasChanged()" data-popover="Use arrows &#8645; or numpad to set your Functional Threshold Power in Watts" data-popover-trigger="mouseenter"></input>
@@ -45,57 +45,13 @@
             </thead>
         </table>
     </form>
-    <h3 data-ng-hide="false"><span class="label label-default">Your Heart Rate Reserve (HRR) zones</span></h3>
+    <h3 data-ng-hide="false"><span class="label label-default">{{'settings/healthSettings/your_hrr_zones'| translationFilter}}</span></h3>
     <div class="row">
         <div class="col-md-6">
             <div data-health-custom-zones data-hr-zones="zones" data-user-max-hr="{{userMaxHr}}" data-user-rest-hr="{{userRestHr}}" align="center"></div>
         </div>
         <div class="col-md-6">
-            <div class="healthCustomZonesExplanations">
-
-                <h3>How to use custom Heart Rate Reserve zones?</h3>
-                <blockquote>
-
-                    <h4>Edit existing zone</h4>
-                    <blockquote>
-                        Click into HRR fields of the zone you want to edit. A zone is always defined between 2 HRR fields.
-                        <br/>
-                        <br/>Hint: You can use input arrows or keyboard arrows to set the value.
-                    </blockquote>
-
-                    <h4>Add a Last HRR zone</h4>
-                    <blockquote>
-                        Click “Add a Last Zone” button to add a new zone at the end of current zones. The previous last zone will be split twice to add the new zone.
-                    </blockquote>
-
-                    <h4>Remove HRR zone</h4>
-                    <blockquote>
-                        Click “Del Last Zone” button to remove the zone at the end of current zones. The 2 latest zones will be merged to perform this operation.
-                    </blockquote>
-
-                    <h4>Reset HRR zones</h4>
-                    <blockquote>
-                        Click “Reset Zones” to apply default factory zones.
-                    </blockquote>
-                </blockquote>
-
-                <h3>What is Heart Rate Reserve?</h3>
-                <blockquote>
-                    Heart Rate Reserve (HRR) is the difference between your Maximum Heart Rate (Max HR) and Resting Heart Rate (Rest HR). This is basically your global heart capacity :)
-                    <br/>
-                    <br/>%HRR = 0% is your Rest HR (={{userRestHr}} bpm)
-                    <br/>%HRR = 100% is your Max HR (={{userMaxHr}} bpm)
-                </blockquote>
-
-                <h3>What are Heart Rate Reserve Zones?</h3>
-                <blockquote>
-                    Heart Rate Reserve Zones represent a distribution of your heart efforts during an activity into zones. Each zone has a beginning and ending HRR value.
-                </blockquote>
-                <h3>Where to see HRR Zone distribution?</h3>
-                <blockquote>
-                    Inside a Strava activity. Of course you must have heart rate data associated to your activity.
-                </blockquote>
-
+            <div class="healthCustomZonesExplanations" ng-bind-html="'settings/healthSettings/health_zone_explain'| translationFilter">
             </div>
         </div>
     </div>

--- a/hook/extension/package.json
+++ b/hook/extension/package.json
@@ -18,6 +18,7 @@
     "angular": "1.5.5",
     "angular-bootstrap": "0.12.2",
     "angular-route": "1.5.5",
+    "angular-sanitize": "1.5.6",
     "bootstrap": "3.3.6",
     "chart.js": "1.0.*",
     "fiber": "1.0.4",


### PR DESCRIPTION
@thomaschampagne Enabled translation for Health and Zone settings pages. But, hit an obstacle with header titles. The javascript running the translation is not loaded before the headerNav is loaded so, cannot dynamically translation the strings.

Any suggestions on how to solve this are welcome?