### PR TITLE
Fix issues with heart rate adjusted recent efforts for running

### DIFF
--- a/hook/extension/js/Helper.ts
+++ b/hook/extension/js/Helper.ts
@@ -240,11 +240,11 @@ class Helper {
     }
 
     public static safeMax(a: number, b: number): number {
-        return typeof a == "undefined" ? b : Math.max(a, b);
+        return a == null ? b : Math.max(a, b);
     }
 
     public static safeMin(a: number, b: number): number {
-        return typeof a == "undefined" ? b : Math.min(a, b);
+        return a == null ? b : Math.min(a, b);
     }
 
 }

--- a/hook/extension/js/modifiers/ActivitySegmentTimeComparisonModifier.ts
+++ b/hook/extension/js/modifiers/ActivitySegmentTimeComparisonModifier.ts
@@ -7,6 +7,7 @@ interface EffortInfo {
     elapsed_time_raw: number;
     avg_watts: number;
     avg_heart_rate: number;
+    has_watts: boolean;
 
     start_date_local: Date;
     start_date_local_raw: string;

--- a/hook/extension/js/modifiers/SegmentRecentEffortsHRATimeModifier.ts
+++ b/hook/extension/js/modifiers/SegmentRecentEffortsHRATimeModifier.ts
@@ -117,7 +117,8 @@ class SegmentRecentEffortsHRATimeModifier implements IModifier {
                 // when watts are present, show watts, not time (used for bike activities)
                 let showWatts = false;
                 fetchedLeaderBoardData.forEach((r) => {
-                    if (r.avg_watts != null) {
+                    // detection based only on avg_watts == null seems unreliable, some runs have avg_watts present
+                    if (r.has_watts && r.avg_watts != null) {
                         showWatts = true;
                     }
                 });


### PR DESCRIPTION
When displaying heart rate adjusted recent efforts for running, some issues were introduced in last fixes.

First fix handles running data which have `has_watts=false`, but still have `avg_watts` present. This has happened on one recent activity of mine.

Seconds fix is more important: Initializing values made inspections disapeared in the IDE, but safeMin / safeMax were not unable to handle `null` values properly, they expected `undefined` ones.
This has caused issues when oldest efforts did not contain HR data.
