### PR TITLE
Fixed: recent efforts running time range wrong sometimes

### DIFF
--- a/hook/extension/js/Helper.ts
+++ b/hook/extension/js/Helper.ts
@@ -240,11 +240,11 @@ class Helper {
     }
 
     public static safeMax(a: number, b: number): number {
-        return typeof a == "undefined" ? b : Math.max(a, b);
+        return a == null ? b : Math.max(a, b);
     }
 
     public static safeMin(a: number, b: number): number {
-        return typeof a == "undefined" ? b : Math.min(a, b);
+        return a == null ? b : Math.min(a, b);
     }
 
 }


### PR DESCRIPTION
Fixed: recent efforts running time range wrong when old efforts were missing HR data (introduced in 5f2d8c06c5131939837fe3571e4865ef812c1f08)

The helper functions `safeMin` / `safeMax` expected `undefined` values, not `null` values. Current version handles `null`, and it should handle both if needed, as `undefined == null` (see http://stackoverflow.com/a/12690122/16673).