### PR TITLE
Fixed: Recent efforts for running could rarely show watts instead of time

### DIFF
--- a/hook/extension/js/modifiers/SegmentRecentEffortsHRATimeModifier.ts
+++ b/hook/extension/js/modifiers/SegmentRecentEffortsHRATimeModifier.ts
@@ -115,10 +115,11 @@ class SegmentRecentEffortsHRATimeModifier implements IModifier {
                 }
 
                 // when watts are present, show watts, not time (used for bike activities)
-                let showWatts = false;
+                let showWatts = true;
                 fetchedLeaderBoardData.forEach((r) => {
-                    if (r.avg_watts != null) {
-                        showWatts = true;
+                    // detection based only on single avg_watts != null seems unreliable, I have seen a run effort with avg_watts present
+                    if (r.avg_watts == null) {
+                        showWatts = false;
                     }
                 });
 


### PR DESCRIPTION
In one of my recent efforts one running effort is returning avg_watts value present. Current code decided to show watts instead of a time as a scale for heart rate adjusted data.
This looks like a Strava bug - why should running ever report watts?

I have changed it so shat watts are shown only when all efforts have avg_watts present to work around this. I did not see any failure with any of my bike or running segment I have checked.

For my record:
- the segment is https://www.strava.com/segments/12556730?filter=my_results.
- the activity is https://www.strava.com/activities/633052397

Note: the activity was fixed using [SNAP utility](http://strava-tools.raceshape.com/snap/) and uploaded again - chance is it might be causing this?