### PR TITLE
Actually deal with other number formats when parsing goals

### DIFF
--- a/hook/extension/js/modifiers/GoalsModifier.ts
+++ b/hook/extension/js/modifiers/GoalsModifier.ts
@@ -46,7 +46,8 @@ class GoalsModifier implements IModifier {
                     activityType =
                         activityType[0].toUpperCase() + activityType.slice(1);
                     let $actual = $barYearly.find('.actual');
-                    let actual = this.parseActual($actual.text());
+                    let actual = parseInt(
+                        $actual.text().replace(/[^0-9]/g, ""), 10);
                     if (goal.value !== 0) {
                         if (goal.units === GoalUnit.METRES) {
                             actual = actual * 1000;
@@ -64,30 +65,6 @@ class GoalsModifier implements IModifier {
                 }
             );
         });
-    }
-
-    /**
-     * Parse the actual goal attainment from a string.
-     *
-     * This parses a number formatted as a string into an actual number.
-     * Thousand separators and the decimal component are stripped away
-     * before parsing the number into an integer.
-     *
-     * All non-numeric characters are considered potential thousand
-     * separators and decimal markers in the number.
-     *
-     * @param actualText: The formatted number to parse.
-     */
-    private parseActual = (actualText: string): number => {
-        let separatorPrimaryIndex = actualText.search(/[^0-9]/);
-        let separatorPrimary = actualText.charAt(separatorPrimaryIndex);
-        let separatorSecondaryIndex = actualText.search(
-            new RegExp(`[^0-9${separatorPrimary}]`));
-        if (separatorSecondaryIndex !== -1) {  // Decimal part
-            actualText = actualText.slice(separatorSecondaryIndex)
-        }
-        let numberString = actualText.replace(/[^0-9]/g, "");
-        return parseInt(numberString, 10);
     }
 
     /**

--- a/hook/extension/js/modifiers/GoalsModifier.ts
+++ b/hook/extension/js/modifiers/GoalsModifier.ts
@@ -73,19 +73,20 @@ class GoalsModifier implements IModifier {
      * Thousand separators and the decimal component are stripped away
      * before parsing the number into an integer.
      *
-     * Both commas and periods are treated as potential thousand separators
-     * and decimal markers in the number.
+     * All non-numeric characters are considered potential thousand
+     * separators and decimal markers in the number.
      *
      * @param actualText: The formatted number to parse.
      */
     private parseActual = (actualText: string): number => {
-        let usesComma = actualText.search(/[,]/) !== -1;
-        let usesPeriod = actualText.search(/[.]/) !== -1;
-        let hasDecimal = usesComma && usesPeriod;
-        if (hasDecimal) {
-            actualText = actualText.replace(/[,.]\d*$/, "");
+        let separatorPrimaryIndex = actualText.search(/[^0-9]/);
+        let separatorPrimary = actualText.charAt(separatorPrimaryIndex);
+        let separatorSecondaryIndex = actualText.search(
+            new RegExp(`[^0-9${separatorPrimary}]`));
+        if (separatorSecondaryIndex !== -1) {  // Decimal part
+            actualText = actualText.slice(separatorSecondaryIndex)
         }
-        let numberString = actualText.replace(/[,.]/g, "");
+        let numberString = actualText.replace(/[^0-9]/g, "");
         return parseInt(numberString, 10);
     }
 


### PR DESCRIPTION
Follow up for #302 and this time I swear it's for realsies. 😊

Turns out Strava actually has loads of (well, at least three) different number formats. As @Langlaeufer astutely pointed out in #302, I should just strip all non-numeric characters, instead of trying to be smart. My bad. Also I got rid of the whole trying to deal with decimals. I don't think Strava actually includes them anyway -- although I wish I could be more confident in that assertion.