### PR TITLE
Corrected date comparison for seconds/miliseconds

### DIFF
--- a/plugin/core/scripts/modifiers/GoalsModifier.ts
+++ b/plugin/core/scripts/modifiers/GoalsModifier.ts
@@ -241,7 +241,8 @@ class GoalsModifier implements IModifier {
                         let monthStartReached = false;
                         activities.push(... response.models);
                         for (let activity of response.models) {
-                            if (activity.start_date_local_raw < +monthStart) {
+                            // activity.start_date_local_raw is in seconds, monthStart is in ms
+                            if (activity.start_date_local_raw*1000 < +monthStart) {
                                 monthStartReached = true;
                             }
                         }


### PR DESCRIPTION
Comparing dates with different units, monthsStart is taken from a Date object which gives miliseconds, start_date_local_raw is in seconds.

This prevented 2nd (3rd, 4th..) pages of activities from being loaded and meant that monthly stats for users with more than 20 activities ( 1 page of results) or with mixed activity types did not see the full total of distance travelled for the month in the progress bars.