### PR TITLE
adds option to hide virtual rides from activity feed

### DIFF
--- a/plugin/core/scripts/Content.ts
+++ b/plugin/core/scripts/Content.ts
@@ -74,7 +74,9 @@ class Content {
                         chromeSettings = this.userSettings;
                     }
 
-                    if(_.difference(_.keys(chromeSettings),_.keys(userSettings)).length !== 0){ // If settings shape has changed
+                    let defaultSettings = _.keys(userSettings)
+                    let syncedSettings = _.keys(chromeSettings)
+                    if(_.difference(defaultSettings, syncedSettings).length !== 0){ // If settings shape has changed
                        _.defaults(chromeSettings, userSettings)
                     }
 

--- a/plugin/core/scripts/Content.ts
+++ b/plugin/core/scripts/Content.ts
@@ -74,6 +74,10 @@ class Content {
                         chromeSettings = this.userSettings;
                     }
 
+                    if(_.difference(_.keys(chromeSettings),_.keys(userSettings)).length !== 0){ // If settings shape has changed
+                       _.defaults(chromeSettings, userSettings)
+                    }
+
                     inner.textContent = 'var $ = jQuery;';
                     inner.textContent += 'var stravistiX = new StravistiX(' + JSON.stringify(chromeSettings) + ', ' + JSON.stringify(this.appResources) + ');';
                     inner.onload = () => {

--- a/plugin/core/scripts/StravistiX.ts
+++ b/plugin/core/scripts/StravistiX.ts
@@ -555,7 +555,7 @@ class StravistiX {
         }
 
 
-        if (!this._userSettings.feedHideChallenges && !this._userSettings.feedHideCreatedRoutes && !this._userSettings.feedHideRideActivitiesUnderDistance && !this._userSettings.feedHideRunActivitiesUnderDistance) {
+        if (!this._userSettings.feedHideChallenges && !this._userSettings.feedHideCreatedRoutes && !this._userSettings.feedHideRideActivitiesUnderDistance && !this._userSettings.feedHideRunActivitiesUnderDistance && !this._userSettings.feedHideVirtualRides) {
             return;
         }
 

--- a/plugin/core/scripts/UserSettings.ts
+++ b/plugin/core/scripts/UserSettings.ts
@@ -43,6 +43,7 @@ interface IUserSettings {
     enableBothLegsCadence: boolean;
     feedHideChallenges: boolean;
     feedHideCreatedRoutes: boolean;
+    feedHideVirtualRides: boolean;
     feedHideRideActivitiesUnderDistance: number;
     feedHideRunActivitiesUnderDistance: number;
     displaySegmentTimeComparisonToKOM: boolean;
@@ -274,6 +275,7 @@ let userSettings: IUserSettings = {
     enableBothLegsCadence: false,
     feedHideChallenges: false,
     feedHideCreatedRoutes: false,
+    feedHideVirtualRides: false,
     feedHideRideActivitiesUnderDistance: 0,
     feedHideRunActivitiesUnderDistance: 0,
     displaySegmentTimeComparisonToKOM: true,

--- a/plugin/core/scripts/modifiers/HideFeedModifier.ts
+++ b/plugin/core/scripts/modifiers/HideFeedModifier.ts
@@ -1,3 +1,7 @@
+const VIRTUAL_RIDE: string = "virtualride";
+const RIDE: string = "ride";
+const RUN: string = "run";
+
 class HideFeedModifier implements IModifier {
 
     protected userSettings: IUserSettings;
@@ -25,15 +29,14 @@ class HideFeedModifier implements IModifier {
                 });
             }
 
-            if (this.userSettings.feedHideRideActivitiesUnderDistance > 0 || this.userSettings.feedHideRunActivitiesUnderDistance > 0) {
+            if (this.userSettings.feedHideVirtualRides || this.userSettings.feedHideRideActivitiesUnderDistance > 0 || this.userSettings.feedHideRunActivitiesUnderDistance > 0) {
 
                 let minRideDistanceToHide: number = this.userSettings.feedHideRideActivitiesUnderDistance;
                 let minRunDistanceToHide: number = this.userSettings.feedHideRunActivitiesUnderDistance;
 
                 $('div.feed>.activity').each((index: number, element: Element) => {
 
-                    let type: string = $(element).find('div').first().attr('class').replace('icon-sm', '').replace('  ', ' ').split(' ')[1].replace('icon-sm', '').replace('icon-', '');
-
+                    let type: string = $(element).find('.entry-type-icon .app-icon').attr('class').replace('icon-lg', '').replace('app-icon','').replace('icon-dark','').replace(/\s+/g, '').replace('icon-','')
 
                     let distanceEl = _.filter($(element).find('ul.inline-stats').find('[class=unit]'), function (item) {
                         return ($(item).html() == 'km' || $(item).html() == 'mi');
@@ -41,13 +44,18 @@ class HideFeedModifier implements IModifier {
 
                     let distance: number = parseFloat($(distanceEl).parent().text().replace(',', '.'));
 
+                    // Remove virtual rides
+                    if(this.userSettings.feedHideVirtualRides && type === VIRTUAL_RIDE) {
+                        $(element).remove();
+                    }
+
                     // Remove Ride activities if distance lower than "minRideDistanceToHide", if minRideDistanceToHide equal 0, then keep all.
-                    if ((minRideDistanceToHide > 0) && distance && (distance < minRideDistanceToHide) && (type === "ride" || type === "virtualride")) {
+                    if ((minRideDistanceToHide > 0) && distance && (distance < minRideDistanceToHide) && (type === RIDE || type === VIRTUAL_RIDE)) {
                         $(element).remove();
                     }
 
                     // Remove Run activities if distance lower than "minRunDistanceToHide", if minRunDistanceToHide equal 0, then keep all.
-                    if ((minRunDistanceToHide > 0) && distance && (distance < minRunDistanceToHide) && type === "run") {
+                    if ((minRunDistanceToHide > 0) && distance && (distance < minRunDistanceToHide) && type === RUN) {
                         $(element).remove();
                     }
                 });

--- a/plugin/options/app/services/CommonSettingsService.ts
+++ b/plugin/options/app/services/CommonSettingsService.ts
@@ -296,11 +296,18 @@ app.factory('CommonSettingsService', () => {
                 optionLabels: ['All'],
                 optionHtml: 'This will hide all routes created in the dashboard feed.',
             }, {
-                optionKey: 'feedHideRideActivitiesUnderDistance',
-                optionType: 'number',
-                optionTitle: 'Hide rides activities under distance.',
+                optionKey: 'feedHideVirtualRides',
+                optionType: 'checkbox',
+                optionTitle: 'Hide virtual rides.',
                 optionLabels: ['Cycling'],
-                optionHtml: 'This will hide all cycling rides (also virtual rides) in the dashboard feed if they are under distance you set (KM or MI). Set empty value or "0" to display all cycling rides in your feed',
+                optionHtml: 'This will hide all virtual rides in the dashboard feed.',
+                min: 0
+            }, {
+                optionKey: 'feedHideRunActivitiesUnderDistance',
+                optionType: 'number',
+                optionTitle: 'Hide running activities under distance.',
+                optionLabels: ['Running'],
+                optionHtml: 'This will hide all running activities in the dashboard feed if they are under distance you set (KM or MI). Set empty value or "0" to display all cycling rides in your feed',
                 min: 0
             }, {
                 optionKey: 'feedHideRunActivitiesUnderDistance',

--- a/plugin/options/app/services/CommonSettingsService.ts
+++ b/plugin/options/app/services/CommonSettingsService.ts
@@ -303,11 +303,11 @@ app.factory('CommonSettingsService', () => {
                 optionHtml: 'This will hide all virtual rides in the dashboard feed.',
                 min: 0
             }, {
-                optionKey: 'feedHideRunActivitiesUnderDistance',
+                optionKey: 'feedHideRideActivitiesUnderDistance',
                 optionType: 'number',
-                optionTitle: 'Hide running activities under distance.',
-                optionLabels: ['Running'],
-                optionHtml: 'This will hide all running activities in the dashboard feed if they are under distance you set (KM or MI). Set empty value or "0" to display all cycling rides in your feed',
+                optionTitle: 'Hide rides activities under distance.',
+                optionLabels: ['Cycling'],
+                optionHtml: 'This will hide all cycling rides (also virtual rides) in the dashboard feed if they are under distance you set (KM or MI). Set empty value or "0" to display all cycling rides in your feed',
                 min: 0
             }, {
                 optionKey: 'feedHideRunActivitiesUnderDistance',


### PR DESCRIPTION
Hi,

This PR adds the option to hide virtual rides from the activity feed (I have noticed a lot of them on my feed and I would like the ability to hide them).

It also resolves activity type resolution in the activity feed hider module. Looks like the html structure has changed from when the initial code was written which I guess would mean the minimum distance ride/run filters may not have been working, unless I have misinterpreted what the original code was doing.

This is my first typescript PR so let me know if it is not stylistically correct. I have tried to follow the established patterns in the code as closely as possible.

I think there could be room for improvement around working out whether or not the modifiers should run or not? Maybe using a strategy pattern or something? I didn't want to refactor too much as I am not sure how open to that you are?

Thanks,

Ben