### PR TITLE
Issue #382 Option to hide suggested athletes on dashboard

### DIFF
--- a/plugin/core/scripts/StravistiX.ts
+++ b/plugin/core/scripts/StravistiX.ts
@@ -611,7 +611,7 @@ class StravistiX {
         }
 
 
-        if (!this._userSettings.feedHideChallenges && !this._userSettings.feedHideCreatedRoutes && !this._userSettings.feedHideRideActivitiesUnderDistance && !this._userSettings.feedHideRunActivitiesUnderDistance && !this._userSettings.feedHideVirtualRides) {
+        if (!this._userSettings.feedHideChallenges && !this._userSettings.feedHideCreatedRoutes && !this._userSettings.feedHideRideActivitiesUnderDistance && !this._userSettings.feedHideRunActivitiesUnderDistance && !this._userSettings.feedHideVirtualRides && !this._userSettings.feedHideSuggestedAthletes) {
             return;
         }
 

--- a/plugin/core/scripts/UserSettings.ts
+++ b/plugin/core/scripts/UserSettings.ts
@@ -44,6 +44,7 @@ interface IUserSettings {
     enableBothLegsCadence: boolean;
     feedHideChallenges: boolean;
     feedHideCreatedRoutes: boolean;
+    feedHideSuggestedAthletes: boolean;
     feedHideVirtualRides: boolean;
     feedHideRideActivitiesUnderDistance: number;
     feedHideRunActivitiesUnderDistance: number;
@@ -298,6 +299,7 @@ let userSettings: IUserSettings = {
     enableBothLegsCadence: false,
     feedHideChallenges: false,
     feedHideCreatedRoutes: false,
+    feedHideSuggestedAthletes: false,
     feedHideVirtualRides: false,
     feedHideRideActivitiesUnderDistance: 0,
     feedHideRunActivitiesUnderDistance: 0,

--- a/plugin/core/scripts/modifiers/HideFeedModifier.ts
+++ b/plugin/core/scripts/modifiers/HideFeedModifier.ts
@@ -29,6 +29,11 @@ class HideFeedModifier implements IModifier {
                 });
             }
 
+            // If hide suggested athletes
+            if (this.userSettings.feedHideSuggestedAthletes) {
+                $('#suggested-follow-module').remove(); // Will work as long as id remains "suggested-follow-module"
+            }
+
             if (this.userSettings.feedHideVirtualRides || this.userSettings.feedHideRideActivitiesUnderDistance > 0 || this.userSettings.feedHideRunActivitiesUnderDistance > 0) {
 
                 let minRideDistanceToHide: number = this.userSettings.feedHideRideActivitiesUnderDistance;

--- a/plugin/options/app/services/CommonSettingsService.ts
+++ b/plugin/options/app/services/CommonSettingsService.ts
@@ -296,6 +296,12 @@ app.factory('CommonSettingsService', () => {
                 optionLabels: ['All'],
                 optionHtml: 'This will hide all routes created in the dashboard feed.',
             }, {
+                optionKey: 'feedHideSuggestedAthletes',
+                optionType: 'checkbox',
+                optionTitle: 'Hide suggested athletes',
+                optionLabels: ['All'],
+                optionHtml: 'This will hide the "You Should Follow" section from the dashboard feed sidebar',
+            }, {
                 optionKey: 'feedHideVirtualRides',
                 optionType: 'checkbox',
                 optionTitle: 'Hide virtual rides.',


### PR DESCRIPTION
Addressing issue #382, although based on the screenshot taken when this issue was opened Strava has since moved this section to the sidebar where it does not interfere with the activity feed.