### PR TITLE
Fixing the units on the elevation trend arrow

### DIFF
--- a/plugin/core/scripts/modifiers/AthleteStatsModifier.ts
+++ b/plugin/core/scripts/modifiers/AthleteStatsModifier.ts
@@ -189,7 +189,7 @@ class AthleteStatsModifier implements IModifier {
                     }) + "</small></div></td>" +
                     "<td><div style='white-space: nowrap;'>" + Helper.formatNumber(item.elevation, 0) + " " + this.elevationUnit + this.renderTrendArrow(elevationDifference, function (value: any) {
                         return Helper.formatNumber(Math.abs(value), 0) + " " + this.elevationUnit;
-                    }) + "</div></td>" +
+                    }).bind(this) + "</div></td>" +
                     "<td><div style='white-space: nowrap;'>" + Helper.secondsToDHM(item.time) + this.renderTrendArrow(timeDifference, function (value: any) {
                         return Helper.secondsToDHM(Math.abs(value));
                     }) + "</div></td>" +


### PR DESCRIPTION
The hover text for the trend arrow currently states 'x undefined' instead of 'x ft'.
This commit fixes it by correcting scoping the function so it has access to the elevationUnit.