### PR TITLE
Exclude EBikeRide in Multisports Fitness Trend

### DIFF
--- a/plugin/options/app/services/FitnessDataService.ts
+++ b/plugin/options/app/services/FitnessDataService.ts
@@ -199,6 +199,10 @@ export class FitnessDataService {
 
                         const fitnessActivity: IActivitiesWithFitness = activitiesWithFitnessThatDay[count];
 
+                        if (fitnessActivity.type === "EBikeRide") {
+                            continue;
+                        }
+
                         fitnessObjectOnCurrentDay.ids.push(fitnessActivity.id);
                         fitnessObjectOnCurrentDay.activitiesName.push(fitnessActivity.activityName);
                         fitnessObjectOnCurrentDay.type.push(fitnessActivity.type);


### PR DESCRIPTION
Hi,

I am having a problem on the multisports fitness trend graph where those e-bike rides show up since I started using them for commute now. I don't think having them on the graph are helpful at all.

In the long run, it is probably better(?) to have an option and let user pick the sports that they don't care and exclude them. What do you think?

Thanks,
-Kyle