### PR TITLE
Add toggle for indoor activities on Yearly Progression

### DIFF
--- a/plugin/app/src/app/year-progress/shared/services/year-progress.service.spec.ts
+++ b/plugin/app/src/app/year-progress/shared/services/year-progress.service.spec.ts
@@ -46,13 +46,15 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 
 		// When
 		const progression: YearProgressModel[] = yearProgressService.progression(TEST_SYNCED_MODELS,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		expect(progression).not.toBeNull();
@@ -80,13 +82,15 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 
 		// When
 		const progression: YearProgressModel[] = yearProgressService.progression(TEST_SYNCED_MODELS,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		const yearProgressModel_2018 = progression[3];
@@ -108,6 +112,7 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 
 		const fakeWalkActivity = new SyncedActivityModel();
 		fakeWalkActivity.id = 99;
@@ -128,7 +133,8 @@ describe("YearProgressService", () => {
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		expect(progression).not.toBeNull();
@@ -155,6 +161,7 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 
 		const expectedFirstDay2015 = new ProgressionModel(2015,
 			1,
@@ -209,7 +216,8 @@ describe("YearProgressService", () => {
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		expect(progression).not.toBeNull();
@@ -240,6 +248,7 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = false;
+		const includeIndoorRide = true;
 
 		const expectedLastDay2015 = new ProgressionModel(2015,
 			365,
@@ -269,7 +278,8 @@ describe("YearProgressService", () => {
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		expect(progression).not.toBeNull();
@@ -286,7 +296,7 @@ describe("YearProgressService", () => {
 		done();
 
 	});
-
+	
 	it("should compute progression with imperial system unit", (done: Function) => {
 
 		// Given
@@ -294,6 +304,7 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = false;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 
 		const expectedLastDay2015 = new ProgressionModel(2015,
 			365,
@@ -324,7 +335,8 @@ describe("YearProgressService", () => {
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		expect(progression).not.toBeNull();
@@ -349,6 +361,7 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = [2015, 2017]; // Skip 2016
 		const isMetric = true;
 		const includeCommuteRide = false;
+		const includeIndoorRide = false;
 
 		const expectedLastDay2015 = new ProgressionModel(2015,
 			365,
@@ -371,7 +384,8 @@ describe("YearProgressService", () => {
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Then
 		expect(progression).not.toBeNull();
@@ -394,12 +408,14 @@ describe("YearProgressService", () => {
 		const syncedActivityModels = [];
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 
 		const progressionMethodCall = () => yearProgressService.progression(syncedActivityModels,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 
 		// When, Then
@@ -416,11 +432,13 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 		const progressionMethodCall = () => yearProgressService.progression(TEST_SYNCED_MODELS,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// When, Then
 		expect(progressionMethodCall).toThrowError(YearProgressService.ERROR_NO_TYPES_FILTER);
@@ -435,12 +453,14 @@ describe("YearProgressService", () => {
 		const typesFilter: string[] = ["FakeType"];
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 		const yearsFilter: number[] = []; // All
 		const progressionMethodCall = () => yearProgressService.progression(TEST_SYNCED_MODELS,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// When, Then
 		expect(progressionMethodCall).toThrowError(YearProgressService.ERROR_NO_YEAR_PROGRESS_MODELS);
@@ -498,11 +518,13 @@ describe("YearProgressService", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 		const progression: YearProgressModel[] = yearProgressService.progression(TEST_SYNCED_MODELS,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		const selectedYears: number[] = [2018, 2017, 2016, 2015];
 

--- a/plugin/app/src/app/year-progress/shared/services/year-progress.service.ts
+++ b/plugin/app/src/app/year-progress/shared/services/year-progress.service.ts
@@ -37,10 +37,11 @@ export class YearProgressService {
 	 * @param {number[]} yearsFilter
 	 * @param {boolean} isMetric
 	 * @param {boolean} includeCommuteRide
+	 * @param {boolean} includeIndoorRide
 	 * @returns {YearProgressModel[]}
 	 */
 	public progression(syncedActivityModels: SyncedActivityModel[], typesFilter: string[], yearsFilter: number[],
-					   isMetric: boolean, includeCommuteRide: boolean): YearProgressModel[] {
+					   isMetric: boolean, includeCommuteRide: boolean, includeIndoorRide: boolean): YearProgressModel[] {
 
 		if (_.isEmpty(syncedActivityModels)) {
 			throw new Error(YearProgressService.ERROR_NO_SYNCED_ACTIVITY_MODELS);
@@ -138,7 +139,7 @@ export class YearProgressService {
 
 				for (let i = 0; i < activitiesFound.length; i++) {
 
-					if (!includeCommuteRide && activitiesFound[i].commute) {
+					if ((!includeCommuteRide && activitiesFound[i].commute)||(!includeIndoorRide && activitiesFound[i].trainer)) {
 						continue;
 					}
 

--- a/plugin/app/src/app/year-progress/year-progress-graph/year-progress-graph.component.spec.ts
+++ b/plugin/app/src/app/year-progress/year-progress-graph/year-progress-graph.component.spec.ts
@@ -50,11 +50,13 @@ describe("YearProgressGraphComponent", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 		component.yearProgressModels = yearProgressService.progression(syncedActivityModels,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Inject selected years (here all from syncedActivityModels)
 		component.selectedYears = yearProgressService.availableYears(syncedActivityModels);

--- a/plugin/app/src/app/year-progress/year-progress-table/year-progress-table.component.spec.ts
+++ b/plugin/app/src/app/year-progress/year-progress-table/year-progress-table.component.spec.ts
@@ -52,11 +52,13 @@ describe("YearProgressTableComponent", () => {
 		const yearsFilter: number[] = []; // All
 		const isMetric = true;
 		const includeCommuteRide = true;
+		const includeIndoorRide = true;
 		component.yearProgressModels = yearProgressService.progression(syncedActivityModels,
 			typesFilter,
 			yearsFilter,
 			isMetric,
-			includeCommuteRide);
+			includeCommuteRide,
+			includeIndoorRide);
 
 		// Inject selected years (here all from syncedActivityModels)
 		component.selectedYears = yearProgressService.availableYears(syncedActivityModels);

--- a/plugin/app/src/app/year-progress/year-progress.component.html
+++ b/plugin/app/src/app/year-progress/year-progress.component.html
@@ -59,6 +59,14 @@
 						matTooltip="When enabled, activities flagged as commute are integrated into your progression.">
 						Commute activities
 					</mat-slide-toggle>
+					<span fxFlex="1"></span>
+					<mat-slide-toggle
+						fxFlexAlign="center"
+						[(ngModel)]="includeIndoorRide"
+						(change)="onIncludeIndoorRideToggle()"
+						matTooltip="When enabled, activities flagged as indoor are integrated into your progression.">
+						Indoor activities
+					</mat-slide-toggle>
 				</div>
 			</div>
 

--- a/plugin/app/src/app/year-progress/year-progress.component.ts
+++ b/plugin/app/src/app/year-progress/year-progress.component.ts
@@ -41,7 +41,8 @@ export class YearProgressComponent implements OnInit {
 	public static readonly LS_SELECTED_ACTIVITY_TYPES_KEY: string = "yearProgress_selectedActivityTypes";
 	public static readonly LS_SELECTED_PROGRESS_TYPE_KEY: string = "yearProgress_selectedProgressType";
 	public static readonly LS_INCLUDE_COMMUTE_RIDES_KEY: string = "yearProgress_includeCommuteRide";
-
+	public static readonly LS_INCLUDE_INDOOR_RIDES_KEY: string = "yearProgress_includeIndoorRide";
+	
 	public progressTypes: YearProgressTypeModel[];
 	public availableActivityTypes: string[] = [];
 	public selectedActivityTypes: string[] = [];
@@ -49,6 +50,7 @@ export class YearProgressComponent implements OnInit {
 	public selectedYears: number[];
 	public selectedProgressType: YearProgressTypeModel;
 	public includeCommuteRide: boolean;
+	public includeIndoorRide: boolean;
 	public isMetric: boolean;
 	public yearProgressModels: YearProgressModel[]; // Progress for each year
 	public syncedActivityModels: SyncedActivityModel[]; // Stored synced activities
@@ -126,7 +128,10 @@ export class YearProgressComponent implements OnInit {
 
 		// Keep commute rides in stats by default
 		this.includeCommuteRide = (localStorage.getItem(YearProgressComponent.LS_INCLUDE_COMMUTE_RIDES_KEY) !== "false");
-
+		
+		// Keep indoor rides in stats by default
+		this.includeIndoorRide = (localStorage.getItem(YearProgressComponent.LS_INCLUDE_INDOOR_RIDES_KEY) !== "false");
+		
 		// Find all unique sport types
 		const activityCountByTypeModels = this.yearProgressService.activitiesByTypes(this.syncedActivityModels);
 		this.availableActivityTypes = _.map(activityCountByTypeModels, "type");
@@ -169,7 +174,8 @@ export class YearProgressComponent implements OnInit {
 			this.selectedActivityTypes,
 			null, // All Years
 			this.isMetric,
-			this.includeCommuteRide);
+			this.includeCommuteRide,
+			this.includeIndoorRide);
 	}
 
 	/**
@@ -204,6 +210,12 @@ export class YearProgressComponent implements OnInit {
 		this.progression();
 		localStorage.setItem(YearProgressComponent.LS_INCLUDE_COMMUTE_RIDES_KEY, JSON.stringify(this.includeCommuteRide));
 	}
+	
+	public onIncludeIndoorRideToggle(): void {
+		this.progression();
+		localStorage.setItem(YearProgressComponent.LS_INCLUDE_INDOOR_RIDES_KEY, JSON.stringify(this.includeIndoorRide));
+	}
+	
 
 	public onShowOverview(): void {
 


### PR DESCRIPTION
feature req #598

Adds toggle next to the commute toggle. Functions in much the same way.

Only tested with manual entries, both ones set as a "virtual ride" and those tagged as "indoor cycling" set the SyncedActivityModel.trainer to **true**